### PR TITLE
Add canonical string with http method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 [ApiAuth][]-compatible package for signing and verifying HTTP requests in golang.
 
+## IMPORTANT!: Security Update
+In order to prevent a security vulnerability present in the reference version of
+[ApiAuth][] we have added functions in order to sign and verify requests with a
+canonical string that includes the HTTP method. We have added the fucntions
+`SignWithMethod` and `CanonicalStringWithMethod`, and the `Verify` function has
+been modified to accept requests where the request signature matches
+`CanonicalString` OR `CanonicalStringWithMethod`. In the future the old versions
+will be removed and canonical strings will only be considered a match if they 
+include the request method. We recommend you start using the new way of siging
+requests immediately.
+
 ## Usage
 
 Signing a request:

--- a/apiauth.go
+++ b/apiauth.go
@@ -40,6 +40,25 @@ func Sign(r *http.Request, accessID, secret string) error {
 	return nil
 }
 
+// SignWithMethod computs the signature of the given HTTP request
+// as in Sign except that the canonical string includes the HTTP
+// request method.
+func SignWithMethod(r *http.Request, accessID, secret string) error {
+	if err := sufficientHeaders(r); err != nil {
+		return err
+	}
+
+	preexisting := r.Header.Get("Authorization")
+	if preexisting != "" {
+		return fmt.Errorf("Authorization header already present")
+	}
+
+	sig := Compute(CanonicalStringWithMethod(r), secret)
+	r.Header.Set("Authorization", fmt.Sprintf("APIAuth %s:%s", accessID, sig))
+
+	return nil
+}
+
 // Verify checks a request for validity: all required headers
 // are present and the signature matches.
 func Verify(r *http.Request, secret string) error {
@@ -57,7 +76,7 @@ func Verify(r *http.Request, secret string) error {
 		return err
 	}
 
-	if VerifySignature(sig, CanonicalString(r), secret) {
+	if VerifySignature(sig, CanonicalString(r), secret) || VerifySignature(sig, CanonicalStringWithMethod(r), secret) {
 		return nil
 	}
 
@@ -127,6 +146,15 @@ func CanonicalString(r *http.Request) string {
 		header.Get("Content-MD5"),
 		uri,
 		header.Get("Date"),
+	}, ",")
+}
+
+// CanonicalStringWithMethod returns a canonical string as in CanonicalString
+// but also includes the request method
+func CanonicalStringWithMethod(r *http.Request) string {
+	return strings.Join([]string{
+		strings.ToUpper(r.Method),
+		CanonicalString(r),
 	}, ",")
 }
 


### PR DESCRIPTION
:green_heart: 

To match the changes proposed in the reference implementation, mgomes/api_auth,
I added the ability to generate and match against the canonical string with and
without the HTTP Method.
