### PR TITLE
Escape the URL path when constructing the canonical string

### DIFF
--- a/apiauth.go
+++ b/apiauth.go
@@ -130,7 +130,7 @@ func DateForTime(t time.Time) string {
 // CanonicalString returns the canonical string used for the signature
 // based on the headers in the given request.
 func CanonicalString(r *http.Request) string {
-	uri := r.URL.Path
+	uri := r.URL.EscapedPath()
 	if uri == "" {
 		uri = "/"
 	}

--- a/apiauth_test.go
+++ b/apiauth_test.go
@@ -37,6 +37,12 @@ func TestCanonicalString(t *testing.T) {
 	require.Equal(t, want, CanonicalString(req))
 }
 
+func TestCanonicalStringEncoded(t *testing.T) {
+	req, _ := http.NewRequest("GET", "http://localhost:9000/search/K/Westcott%20Schaffer/1982-05-17", nil)
+	want := `GET,,,/search/K/Westcott%20Schaffer/1982-05-17,`
+	require.Equal(t, want, CanonicalStringWithMethod(req))
+}
+
 func TestCanonicalStringWithMethod(t *testing.T) {
 	req, _ := http.NewRequest("POST", "http://example.com/some/path?x=1&b=2", nil)
 


### PR DESCRIPTION
💚 

Our version didn't match what the reference implementation does with escaped URL paths.

``` ruby
# reference impl
require 'api_auth'
require 'net/http'

uri = URI('http://localhost:9000/search/K/Westcott%20Schaffer/1982-05-17')
req = Net::HTTP::Get.new(uri)
headers = ApiAuth::Headers.new(req)
puts headers.canonical_string
# output: 'GET,,,/search/K/Westcott%20Schaffer/1982-05-17,'
```

But running the [same test](https://github.com/packrat386/apiauth/blob/7998244e49d17152e82ada5c16c880e01423e575/apiauth_test.go#L40) against master gave

```
go test
--- FAIL: TestCanonicalStringEnocded (0.00s)
        Error Trace:    apiauth_test.go:43
        Error:          Not equal: "GET,,,/search/K/Westcott%20Schaffer/1982-05-17," (expected)
                != "GET,,,/search/K/Westcott Schaffer/1982-05-17," (actual)

FAIL
exit status 1
FAIL    github.com/pd/apiauth   0.009s
```

The solution is to use the escaped version of the path instead of the unescaped version that `net/url` gives by default with `url.Path`
