### PR TITLE
add support for http.NoBody

### DIFF
--- a/apiauth.go
+++ b/apiauth.go
@@ -172,16 +172,18 @@ func sufficientHeaders(r *http.Request) error {
 		return fmt.Errorf("No Date header present")
 	}
 
-	if r.Body != nil {
-		contentType := r.Header.Get("Content-Type")
-		if contentType == "" {
-			return fmt.Errorf("No Content-Type header present")
-		}
+	if r.Body == nil || r.Body == http.NoBody {
+		return nil
+	}
 
-		contentMD5 := r.Header.Get("Content-MD5")
-		if contentMD5 == "" {
-			return fmt.Errorf("No Content-MD5 header present")
-		}
+	contentType := r.Header.Get("Content-Type")
+	if contentType == "" {
+		return fmt.Errorf("No Content-Type header present")
+	}
+
+	contentMD5 := r.Header.Get("Content-MD5")
+	if contentMD5 == "" {
+		return fmt.Errorf("No Content-MD5 header present")
 	}
 
 	return nil

--- a/apiauth_test.go
+++ b/apiauth_test.go
@@ -199,6 +199,13 @@ func TestVerify(t *testing.T) {
 	require.NoError(t, Verify(req, "secret"))
 }
 
+func TestVerifyNoBody(t *testing.T) {
+	req, _ := http.NewRequest("GET", "http://example.com", http.NoBody)
+	req.Header.Set("Date", "Fri, 20 Mar 2015 19:37:40 GMT")
+	req.Header.Set("Authorization", "APIAuth me:N7N1BXAWv6+RXos4vSAAd7D0XJY=")
+	require.NoError(t, Verify(req, "secret"))
+}
+
 func TestVerify_WithMethod(t *testing.T) {
 	req, _ := http.NewRequest("POST", "http://example.com/some/path?x=1&b=2", nil)
 


### PR DESCRIPTION
Go 1.8 added the http.NoBody type.  

I was trying to verify a request, and it kept returning a Content-Type header error even though it was a GET request (using Postman), so this PR solves my particular problem. I was actually trying to set the Content-Type header to "application/json" but Go was ignoring it since it's not a valid header for GET requests.