### PR TITLE
Add Timestamp header as a Date header fallback to support browser calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,14 @@
 [ApiAuth][]-compatible package for signing and verifying HTTP requests in golang.
 
 ## IMPORTANT!: Security Update
+
 In order to prevent a security vulnerability present in the reference version of
 [ApiAuth][] we have added functions in order to sign and verify requests with a
 canonical string that includes the HTTP method. We have added the fucntions
 `SignWithMethod` and `CanonicalStringWithMethod`, and the `Verify` function has
 been modified to accept requests where the request signature matches
 `CanonicalString` OR `CanonicalStringWithMethod`. In the future the old versions
-will be removed and canonical strings will only be considered a match if they 
+will be removed and canonical strings will only be considered a match if they
 include the request method. We recommend you start using the new way of siging
 requests immediately.
 
@@ -17,31 +18,31 @@ requests immediately.
 
 Signing a request:
 
-~~~go
+```go
 import "github.com/pd/apiauth"
 
 req, _ := http.NewRequest("GET", "http://example.com", nil)
 
-// The `Date` header _must_ be present.
+// The `Date` or `Timestamp` header _must_ be present.
 // If the request body is set, `Content-Type` and `Content-MD5` must
 // also be present.
 req.Header.Set("Date", apiauth.Date())
 
 err := apiauth.Sign(req, "access_id", "secret_key")
-~~~
+```
 
 Verifying a request:
 
-~~~go
+```go
 err := apiauth.Verify(req, "secret_key")
 if err != nil {
   // Failed.
 }
-~~~
+```
 
 Functions are exposed for the lower-level operations, as well, in case you need more granular control:
 
-~~~go
+```go
 // Given a request, returns the `<Content-Type>,<MD5>,<URI>,<Date>` string used for the HMAC.
 str := apiauth.CanonicalString(req)
 
@@ -54,19 +55,19 @@ apiauth.Date()
 // Or a given time:
 t := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
 apiauth.DateForTime(t)
-~~~
+```
 
 ## Caveats
 
 This implementation is intentionally somewhat less "friendly" than mgomes' [Ruby implementation][ApiAuth]:
 
-* Only the `Authorization` header is set for you by `apiauth.Sign`; setting the `Date`, `Content-Type`
+- Only the `Authorization` header is set for you by `apiauth.Sign`; setting the `Date`, `Content-Type`
   and `Content-MD5` headers is the caller's responsibility.
-* The `apiauth.Verify` function does *not* enforce a maximum time duration between the `Date` header
+- The `apiauth.Verify` function does _not_ enforce a maximum time duration between the `Date` header
   in a request and the matching `Date` value computed by the server. Protection against replay attacks
   is the caller's responsibility. (**NB**: but maybe shouldn't be; I'm just being lazy right now, as
   it's already handled in the application I'm writing this for)
-* The `apiauth.Verify` function does *not* validate the `Content-MD5` header: doing so would require
+- The `apiauth.Verify` function does _not_ validate the `Content-MD5` header: doing so would require
   reading the entire request body into memory at least once, which is undesirable in many use cases.
   Verification of the payload MD5 is the caller's responsibility.
 

--- a/apiauth.go
+++ b/apiauth.go
@@ -141,11 +141,16 @@ func CanonicalString(r *http.Request) string {
 
 	header := r.Header
 
+	date := header.Get("Date")
+	if date == "" {
+		date = header.Get("Timestamp")
+	}
+
 	return strings.Join([]string{
 		header.Get("Content-Type"),
 		header.Get("Content-MD5"),
 		uri,
-		header.Get("Date"),
+		date,
 	}, ",")
 }
 
@@ -167,9 +172,8 @@ func Compute(canonicalString, secret string) string {
 }
 
 func sufficientHeaders(r *http.Request) error {
-	date := r.Header.Get("Date")
-	if date == "" {
-		return fmt.Errorf("No Date header present")
+	if r.Header.Get("Date") == "" && r.Header.Get("Timestamp") == "" {
+		return fmt.Errorf("No Date or Timestamp header present")
 	}
 
 	if r.Body == nil || r.Body == http.NoBody {

--- a/apiauth_test.go
+++ b/apiauth_test.go
@@ -199,6 +199,13 @@ func TestVerify(t *testing.T) {
 	require.NoError(t, Verify(req, "secret"))
 }
 
+func TestVerify_FallbackTimestamp(t *testing.T) {
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	req.Header.Set("Timestamp", "Fri, 20 Mar 2015 19:37:40 GMT")
+	req.Header.Set("Authorization", "APIAuth me:N7N1BXAWv6+RXos4vSAAd7D0XJY=")
+	require.NoError(t, Verify(req, "secret"))
+}
+
 func TestVerifyNoBody(t *testing.T) {
 	req, _ := http.NewRequest("GET", "http://example.com", http.NoBody)
 	req.Header.Set("Date", "Fri, 20 Mar 2015 19:37:40 GMT")

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/pd/apiauth
+
+go 1.19
+
+require github.com/stretchr/testify v1.8.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,17 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This PR adds support for the `Timestamp` header as fallback of the `Date` header. This will enable browsers to make auth calls and verify them using this library since [browsers cannot set the `Date` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Date)